### PR TITLE
Remove the setting option from bottom navigation

### DIFF
--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -16,10 +16,4 @@
         android:icon="@drawable/img_task_temp"
         android:title="@string/title_tasks" />
 
-    <item
-        android:id="@+id/navigation_settings"
-        android:icon="@drawable/img_settings_temp"
-        android:title="@string/title_settings" />
-
-
 </menu>


### PR DESCRIPTION
According to Material design: https://material.io/components/bottom-navigation#usage, bottom navigation should not be used for user preferences or settings.

Since we have not decided yet what to do with setting page, I suggest removing from bottom navigation as for now.